### PR TITLE
fix: correct cron schedule for profile-summary-cards workflow

### DIFF
--- a/.github/workflows/profile-summary-cards.yml
+++ b/.github/workflows/profile-summary-cards.yml
@@ -2,7 +2,7 @@ name: GitHub-Profile-Summary-Cards
 
 on:
   schedule: # execute every 24 hours
-    - cron: "* */24 * * *"
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 概要

- `profile-summary-cards.yml` のcron式の誤りを修正
- 誤: `* */24 * * *`（0時台に毎分実行という意味になっていた）
- 正: `0 0 * * *`（毎日UTC 0時0分に1回実行）

## 背景

- GitHubの非アクティブポリシーにより、スケジュールワークフローが `disabled_inactivity` 状態になっていた
- 誤ったcron式が原因でCIが正常に定期実行されていなかった

## テスト計画

- [ ] PRマージ後にワークフローを手動で有効化（`gh workflow enable`）
- [ ] `workflow_dispatch` で手動実行して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)